### PR TITLE
etm: add watchers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,24 +7,22 @@
 package agent
 
 import (
-	"unsafe"
-
+	"jsouthworth.net/go/dyn"
 	"jsouthworth.net/go/etm/atom"
-	"jsouthworth.net/go/etm/internal/unsafe/ref"
-	"jsouthworth.net/go/immutable/queue"
+	"jsouthworth.net/go/etm/internal/jobq"
 )
 
 // Agent is a mechanism to manage a single piece of state.
 type Agent struct {
 	state *atom.Atom
-	queue ref.Ref
+	queue *jobq.Queue
 }
 
 // New returns a new agent with an initial value of s.
 func New(s interface{}) *Agent {
 	return &Agent{
 		state: atom.New(s),
-		queue: ref.Make(unsafe.Pointer(queue.Empty())),
+		queue: jobq.New(runAction),
 	}
 }
 
@@ -33,18 +31,8 @@ func New(s interface{}) *Agent {
 // function of the type func(old aT, args...) rT where aT is the old
 // type of the agent and rT is the desired type of the atom.
 func (a *Agent) Send(fn interface{}, args ...interface{}) *Agent {
-	action := &agentRequest{fn: fn, args: args}
-	var prev unsafe.Pointer
-	for {
-		prev = a.queue.Load()
-		new := unsafe.Pointer((*queue.Queue)(prev).Push(action))
-		if a.queue.CompareAndSwap(prev, new) {
-			break
-		}
-	}
-	if (*queue.Queue)(prev).Length() == 0 {
-		go a.run()
-	}
+	action := &agentRequest{state: a.state, fn: fn, args: args}
+	a.queue.Enqueue(action)
 	return a
 }
 
@@ -53,25 +41,54 @@ func (a *Agent) Deref() interface{} {
 	return a.state.Deref()
 }
 
-func (a *Agent) run() {
-	for {
-		action := (*queue.Queue)(a.queue.Load()).First().(*agentRequest)
-		a.state.Swap(action.fn, action.args...)
-		var next *queue.Queue
-		for {
-			prev := a.queue.Load()
-			next = (*queue.Queue)(prev).Pop()
-			if a.queue.CompareAndSwap(prev, unsafe.Pointer(next)) {
-				break
-			}
-		}
-		if next.Length() == 0 {
-			break
-		}
-	}
+func runAction(val interface{}) {
+	action := val.(*agentRequest)
+	action.state.Swap(action.fn, action.args...)
 }
 
 type agentRequest struct {
-	fn   interface{}
-	args []interface{}
+	state *atom.Atom
+	fn    interface{}
+	args  []interface{}
+}
+
+// Watch adds function to be called when the value of the atom changes.
+//
+// Watchers must be functions of the following form:
+// func(key kT, atom *Atom, old oT, new nT)
+// Watchers may return a value or not but any returned value is ignored.
+// The key type must be the type of the key passed in when the watcher
+// is added, the Value types must be the type of the atom. If the atom
+// can take arbitrary types then the watcher should take type interface{}.
+//
+// Watchers are only called when the value actually changes not on every
+// Swap.
+//
+// All watchers are called asynchronously when the atom changes, this means
+// that one should not deref the atom in the watcher but should used the
+// passed in old and new values. Dispatches to the watchers are queued so
+// the set of watchers for a given update are called then the set for the
+// next and so on.
+func (a *Agent) Watch(key interface{}, fn interface{}, args ...interface{}) *Agent {
+	a.state.Watch(key, &agentWatcher{fn: fn, agent: a}, args...)
+	return a
+}
+
+// Ignore removes the watcher with the passed in key so that on the
+// next update it will not be in the watcher set. This takes effect
+// immediately so if a watcher removes its self, the next update to the
+// atom will not contain the watcher.
+func (a *Agent) Ignore(key interface{}) *Agent {
+	a.state.Ignore(key)
+	return a
+}
+
+type agentWatcher struct {
+	fn    interface{}
+	agent *Agent
+}
+
+func (w *agentWatcher) Apply(args ...interface{}) interface{} {
+	args[1] = w.agent // replace the atom with this agent
+	return dyn.Apply(w.fn, args...)
 }

--- a/atom/atom.go
+++ b/atom/atom.go
@@ -11,16 +11,21 @@ import (
 
 	"jsouthworth.net/go/dyn"
 	"jsouthworth.net/go/etm/internal/unsafe/ref"
+	"jsouthworth.net/go/etm/internal/watchers"
 )
 
 // Atom is a mechanism to manage a single piece of shared state synchronously.
 type Atom struct {
-	state ref.Ref
+	state    ref.Ref
+	watchers *watchers.Watchers
 }
 
 // New returns a new atom with an initial value of s.
 func New(s interface{}) *Atom {
-	return &Atom{state: ref.Make(unsafe.Pointer(&s))}
+	return &Atom{
+		state:    ref.Make(unsafe.Pointer(&s)),
+		watchers: watchers.New(),
+	}
 }
 
 // Deref returns the current value of the atom.
@@ -38,6 +43,7 @@ func (a *Atom) Swap(fn interface{}, args ...interface{}) interface{} {
 		old := a.load()
 		new := dyn.Apply(fn, dyn.PrependArg(*old, args...)...)
 		if a.compareAndSwap(old, &new) {
+			a.notifyWatchers(*old, new)
 			return new
 		}
 	}
@@ -45,8 +51,46 @@ func (a *Atom) Swap(fn interface{}, args ...interface{}) interface{} {
 
 // Reset forcibly updates the value of the atom to new.
 func (a *Atom) Reset(new interface{}) interface{} {
+	old := a.load()
 	a.state.Set(unsafe.Pointer(&new))
+	a.notifyWatchers(*old, new)
 	return new
+}
+
+// Watch adds function to be called when the value of the atom changes.
+//
+// Watchers must be functions of the following form:
+// func(key kT, atom *Atom, old oT, new nT)
+// Watchers may return a value or not but any returned value is ignored.
+// The key type must be the type of the key passed in when the watcher
+// is added, the Value types must be the type of the atom. If the atom
+// can take arbitrary types then the watcher should take type interface{}.
+//
+// Watchers are only called when the value actually changes not on every
+// Swap.
+//
+// All watchers are called asynchronously when the atom changes, this means
+// that one should not deref the atom in the watcher but should used the
+// passed in old and new values. Dispatches to the watchers are queued so
+// the set of watchers for a given update are called then the set for the
+// next and so on.
+func (a *Atom) Watch(key interface{}, fn interface{}, args ...interface{}) *Atom {
+	//TODO: allow more function types.
+	watcher := &watchers.Watcher{
+		Fn:   fn,
+		Args: args,
+	}
+	a.watchers.Add(key, watcher)
+	return a
+}
+
+// Ignore removes the watcher with the passed in key so that on the
+// next update it will not be in the watcher set. This takes effect
+// immediately so if a watcher removes its self, the next update to the
+// atom will not contain the watcher.
+func (a *Atom) Ignore(key interface{}) *Atom {
+	a.watchers.Delete(key)
+	return a
 }
 
 func (a *Atom) load() *interface{} {
@@ -56,4 +100,8 @@ func (a *Atom) load() *interface{} {
 func (a *Atom) compareAndSwap(old, new *interface{}) bool {
 	return a.state.CompareAndSwap(
 		unsafe.Pointer(old), unsafe.Pointer(new))
+}
+
+func (a *Atom) notifyWatchers(old, new interface{}) {
+	a.watchers.Notify(a, old, new)
 }

--- a/internal/jobq/queue.go
+++ b/internal/jobq/queue.go
@@ -1,0 +1,53 @@
+package jobq
+
+import (
+	"unsafe"
+
+	"jsouthworth.net/go/etm/internal/unsafe/ref"
+	"jsouthworth.net/go/immutable/queue"
+)
+
+type Queue struct {
+	ref       ref.Ref
+	processFn func(interface{})
+}
+
+func New(process func(interface{})) *Queue {
+	return &Queue{
+		ref:       ref.Make(unsafe.Pointer(queue.Empty())),
+		processFn: process,
+	}
+}
+
+func (q *Queue) Enqueue(value interface{}) *Queue {
+	var prev unsafe.Pointer
+	for {
+		prev = q.ref.Load()
+		new := unsafe.Pointer((*queue.Queue)(prev).Push(value))
+		if q.ref.CompareAndSwap(prev, new) {
+			break
+		}
+	}
+	if (*queue.Queue)(prev).Length() == 0 {
+		go q.process()
+	}
+	return q
+}
+
+func (q *Queue) process() {
+	for {
+		val := (*queue.Queue)(q.ref.Load()).First()
+		q.processFn(val)
+		var next *queue.Queue
+		for {
+			prev := q.ref.Load()
+			next = (*queue.Queue)(prev).Pop()
+			if q.ref.CompareAndSwap(prev, unsafe.Pointer(next)) {
+				break
+			}
+		}
+		if next.Length() == 0 {
+			break
+		}
+	}
+}

--- a/internal/watchers/watchers.go
+++ b/internal/watchers/watchers.go
@@ -1,0 +1,114 @@
+package watchers
+
+import (
+	"sync"
+	"unsafe"
+
+	"jsouthworth.net/go/dyn"
+	"jsouthworth.net/go/etm/internal/jobq"
+	"jsouthworth.net/go/etm/internal/unsafe/ref"
+	"jsouthworth.net/go/immutable/hashmap"
+)
+
+type Watchers struct {
+	watchers ref.Ref
+	queue    *jobq.Queue
+}
+
+func New() *Watchers {
+	return &Watchers{
+		watchers: ref.Make(unsafe.Pointer(hashmap.Empty())),
+		queue:    jobq.New(notifyWatchers),
+	}
+}
+
+func (w *Watchers) Notify(ref, old, new interface{}) {
+	watchers := w.getWatchers()
+	if watchers.Length() == 0 {
+		return
+	}
+	if dyn.Equal(old, new) {
+		return
+	}
+	w.queue.Enqueue(&watcherJob{
+		old:      old,
+		new:      new,
+		watchers: w,
+		ref:      ref,
+	})
+}
+
+func (w *Watchers) Add(key interface{}, watch *Watcher) {
+	for {
+		old := w.getWatchers()
+		new := old.Assoc(key, watch)
+		if w.watchers.CompareAndSwap(
+			unsafe.Pointer(old),
+			unsafe.Pointer(new)) {
+			return
+		}
+	}
+}
+
+func (w *Watchers) Delete(key interface{}) {
+	for {
+		old := w.getWatchers()
+		new := old.Delete(key)
+		if w.watchers.CompareAndSwap(
+			unsafe.Pointer(old),
+			unsafe.Pointer(new)) {
+			return
+		}
+	}
+}
+
+func (w *Watchers) getWatchers() *hashmap.Map {
+	return (*hashmap.Map)(w.watchers.Load())
+}
+
+type Watcher struct {
+	Fn   interface{}
+	Args []interface{}
+}
+
+func (w *Watcher) Apply(args ...interface{}) interface{} {
+	var fnargs []interface{}
+	if len(w.Args) == 0 {
+		fnargs = args
+	} else {
+		fnargs = make([]interface{}, len(w.Args)+len(args))
+		copy(fnargs, args)
+		copy(fnargs[len(args):], w.Args)
+	}
+	return dyn.Apply(w.Fn, fnargs...)
+}
+
+type watcherJob struct {
+	old, new interface{}
+	watchers *Watchers
+	ref      interface{}
+}
+
+func notifyWatchers(val interface{}) {
+	job := val.(*watcherJob)
+	watchers := job.watchers.getWatchers()
+	switch watchers.Length() {
+	case 0:
+	case 1:
+		// If there is only one watcher don't incur
+		// the overhead of spinning up a goroutine
+		watchers.Range(func(key interface{}, w *Watcher) {
+			dyn.Apply(w, key, job.ref, job.old, job.new)
+		})
+	default:
+		var wg sync.WaitGroup
+		watchers.Range(func(key interface{}, w *Watcher) {
+			wg.Add(1)
+			go func() {
+				dyn.Apply(w, key, job.ref, job.old, job.new)
+				wg.Done()
+			}()
+		})
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
 * Make the agent queue implementation an internal library so it can be reused.
 * Add asynchronous calls to watchers via an agent like queue.
 * Add watchers to atoms.
 * Add watchers to agents.